### PR TITLE
"export =" instead of "module.exports ="

### DIFF
--- a/src/file-system.ts
+++ b/src/file-system.ts
@@ -67,7 +67,7 @@ function getFilePaths (config: PerturbConfig): FilePathResult {
   };
 }
 
-module.exports = function createFsHelpers (c: PerturbConfig) {
+export = function createFsHelpers (c: PerturbConfig) {
   return <FsHelper>{
     setup () {
       setupPerturbDirectory(c);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,17 +2,17 @@
 ///<reference path="../typings/globals/bluebird/index.d.ts"/>
 ///<reference path="../typings/modules/ramda/index.d.ts"/>
 
-const R = require("ramda");
-const Bluebird = require("bluebird");
-const { spawn } = require("child_process");
-const assert = require("assert");
+import R = require("ramda");
+import Bluebird = require("bluebird");
+import { spawn } from "child_process";
+import assert = require("assert");
 
-const getRunner = require("./runners");
-const getReporter = require("./reporters");
-const getMatcher = require("./matchers");
-const makeMutants = require("./make-mutants");
-const makeConfig = require("./make-config");
-const fileSystem = require("./file-system");
+import getRunner = require("./runners");
+import getReporter = require("./reporters");
+import getMatcher = require("./matchers");
+import makeMutants = require("./make-mutants");
+import makeConfig = require("./make-config");
+import fileSystem = require("./file-system");
 
 import {
   PerturbConfig,

--- a/src/make-config.ts
+++ b/src/make-config.ts
@@ -23,7 +23,7 @@ const defaultConfig: PerturbConfig = {
   runner: "mocha-child-process",
 }
 
-module.exports = function makeConfig (userConfig = {}): PerturbConfig {
+export = function makeConfig (userConfig = {}): PerturbConfig {
   let fileConfig;
 
   try {

--- a/src/make-mutants.ts
+++ b/src/make-mutants.ts
@@ -23,7 +23,7 @@ const FS_SETTINGS = {
   encoding: "utf8",
 };
 
-module.exports = function makeMutants (match: Match): Mutant[] {
+export = function makeMutants (match: Match): Mutant[] {
   const { source, tests } = match;
   const { ast, code } = parse(source);
   const paths: Path[] = getMutationPaths(ast).map(p => p.map(String));

--- a/src/matchers/index.ts
+++ b/src/matchers/index.ts
@@ -29,7 +29,7 @@ function runGenerative (
   return R.contains(name, tests) ? [name] : [];
 }
 
-module.exports = function getMatcher (c: PerturbConfig) {
+export = function getMatcher (c: PerturbConfig) {
 
   const matcherPlugin = getMatcherPlugin(c.matcher);
   const {type} = matcherPlugin;

--- a/src/reporters/index.ts
+++ b/src/reporters/index.ts
@@ -21,7 +21,7 @@ function locateReporterPlugins (names) {
   });
 }
 
-module.exports = function get (name: string): ReporterPlugin {
+export = function get (name: string): ReporterPlugin {
   const p = plugins.get(name);
   if (p == null) {
     throw new Error(`unable to locate -RUNNER- plugin "${name}" -- fatal error, exiting`);

--- a/src/runners/index.ts
+++ b/src/runners/index.ts
@@ -24,7 +24,7 @@ function injectPlugins (names) {
   });
 }
 
-module.exports = function get (name: string): RunnerPlugin {
+export = function get (name: string): RunnerPlugin {
   const plugin = plugins.get(name);
   if (plugin == null) {
     throw new Error(`unable to locate -RUNNER- plugin "${name}" -- fatal error, exiting`);


### PR DESCRIPTION
https://www.typescriptlang.org/docs/handbook/modules.html#export--and-import--require

`export =` will compile down to `module.exports =` and when used in conjunction with `import x = require ...`, means the type information gets transferred.
